### PR TITLE
Closes #241:make the compilation cmd more flexible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,14 @@ TARGETS_LIST := $(sort $(patsubst $(TARGETS_DIR)/TARGET_%/,%, $(wildcard $(TARGE
 
 NUMBER_OF_SUPPORTED_CONFIGS := $(shell python3 scripts/build_configurations_helper.py count-supported-configs)
 
+# Lowercase Command Args
+ifneq (,$(app))
+APP = $(app)
+endif
+ifneq (,$(target))
+TARGET = $(target)
+endif
+
 verify_app_target_tuple_is_specified:
 ifeq (,$(findstring $(APP), $(APPS_LIST)))
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,13 @@ This repository contains:
 4. Run make with the target application and board
 
     Ex. Compile the science application for the science board:  
-    `make APP=science TARGET=SCIENCE_REV2`
+
+    `make APP=science TARGET=SCIENCE_REV2` OR `make app=science target=SCIENCE_REV2`
 
     Ex. Compile the arm application for the arm board:  
-    `make APP=arm TARGET=ARM_REV2`
+    `make APP=arm TARGET=ARM_REV2` OR `make app=arm target=ARM_REV2`
+
+    Note: The APP and TARGET variables can be defined in any order.
     
     After compiling an application you should see a message similar to the following:  
     ```shell script


### PR DESCRIPTION
To make it more straight forwards to type the make build command, the TARGET and APP variables in the Makefile have been changed to lowercase, thus, instead of typing: make "TARGET=target APP=app", one can just type: make "target=target app=app".

The README has also been updated accordingly to reflect these changes.

Someone also needs to update the firmware training document as well.