### PR TITLE
Create watchdog module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ add_app_subdirectory(${TEST_APPS_DIR}/test-watchdog)
 # Ensure APP was specified
 if ("$ENV{APP}" STREQUAL "")
     message(FATAL_ERROR "APP was not specified")
-endif ()
+endif()
 
 # Ensure that a target exists for the specified APP
 # https://stackoverflow.com/a/62311397/10173605

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ add_app_subdirectory(${ROVER_APPS_DIR}/gamepad)
 add_app_subdirectory(${ROVER_APPS_DIR}/gimbal)
 add_app_subdirectory(${ROVER_APPS_DIR}/pdb)
 add_app_subdirectory(${ROVER_APPS_DIR}/science)
+add_subdirectory(${ROVER_APPS_DIR}/common)
 
 # Include Test Apps
 add_app_subdirectory(${TEST_APPS_DIR}/test-actuator-controller)
@@ -118,7 +119,7 @@ add_app_subdirectory(${TEST_APPS_DIR}/test-watchdog)
 # Ensure APP was specified
 if ("$ENV{APP}" STREQUAL "")
     message(FATAL_ERROR "APP was not specified")
-endif()
+endif ()
 
 # Ensure that a target exists for the specified APP
 # https://stackoverflow.com/a/62311397/10173605

--- a/libs/utility/include/WatchdogWrapper.h
+++ b/libs/utility/include/WatchdogWrapper.h
@@ -5,11 +5,10 @@ namespace Utility {
 
 class WatchdogWrapper {
  public:
-  static void startWatchdog(std::chrono::milliseconds countdown_ms = 5000ms, std::chrono::milliseconds pet_ms = 1000ms);
-  static void logResetReason();
+  static void startWatchdog(std::chrono::milliseconds countdown_ms);
+  static void logResetReason(void);
 
  private:
-  static void petWatchdog(std::chrono::milliseconds *pet_ms);
-  static Thread pet_thread;
+  static void petWatchdog(void);
 };
 }  // namespace Utility

--- a/libs/utility/include/WatchdogWrapper.h
+++ b/libs/utility/include/WatchdogWrapper.h
@@ -7,8 +7,6 @@ class WatchdogWrapper {
  public:
   static void startWatchdog(std::chrono::milliseconds countdown_ms);
   static void logResetReason(void);
-
- private:
   static void petWatchdog(void);
 };
 }  // namespace Utility

--- a/libs/utility/src/WatchdogWrapper.cpp
+++ b/libs/utility/src/WatchdogWrapper.cpp
@@ -6,17 +6,13 @@
 
 namespace Utility {
 
-Thread WatchdogWrapper::pet_thread;
-
-void WatchdogWrapper::startWatchdog(std::chrono::milliseconds countdown_ms /*= 5000ms*/,
-                                    std::chrono::milliseconds pet_ms /*= 1000ms*/) {
+void WatchdogWrapper::startWatchdog(std::chrono::milliseconds countdown_ms /*= 5000ms*/) {
   uint32_t countdown_uint32 = countdown_ms.count();
   Watchdog &watchdog        = Watchdog::get_instance();
   watchdog.start(countdown_uint32);
-  pet_thread.start(callback(WatchdogWrapper::petWatchdog, &pet_ms));
 }
 
-void WatchdogWrapper::logResetReason() {
+void WatchdogWrapper::logResetReason(void) {
   const reset_reason_t reason = ResetReason::get();
   if (reason == RESET_REASON_WATCHDOG) {
     time_t seconds = time(NULL);
@@ -26,10 +22,7 @@ void WatchdogWrapper::logResetReason() {
   }
 }
 
-void WatchdogWrapper::petWatchdog(std::chrono::milliseconds *pet_ms) {
-  while (1) {
-    Watchdog::get_instance().kick();
-    ThisThread::sleep_for(*pet_ms);
-  }
+void WatchdogWrapper::petWatchdog(void) {
+  Watchdog::get_instance().kick();
 }
 }  // namespace Utility

--- a/rover-apps/arm/CMakeLists.txt
+++ b/rover-apps/arm/CMakeLists.txt
@@ -21,6 +21,8 @@ target_link_libraries(arm
         CANMsg
         #Sensor
         CurrentSensor
+        #common-modules
+        WatchdogModule
         #Other
         uwrt-mars-rover-hw-bridge
         Logger

--- a/rover-apps/arm/include/AppConfig.h
+++ b/rover-apps/arm/include/AppConfig.h
@@ -10,5 +10,4 @@ WatchdogModule arm_watchdog;
 std::vector<Module*> gModules = {
     // put modules here
     &arm_watchdog,
-}
-;
+};

--- a/rover-apps/arm/include/AppConfig.h
+++ b/rover-apps/arm/include/AppConfig.h
@@ -7,7 +7,7 @@
 
 std::chrono::milliseconds countdown_ms = 1000ms; /*Test value*/
 
-WatchdogModule arm_watchdog(countdown_ms);
+Module::WatchdogModule arm_watchdog(countdown_ms);
 
 std::vector<Module*> gModules = {
     // put modules here

--- a/rover-apps/arm/include/AppConfig.h
+++ b/rover-apps/arm/include/AppConfig.h
@@ -5,9 +5,7 @@
 #include "Module.h"
 #include "WatchdogModule.h"
 
-std::chrono::milliseconds countdown_ms = 1000ms; /*Test value*/
-
-WatchdogModule arm_watchdog(countdown_ms);
+WatchdogModule arm_watchdog;
 
 std::vector<Module*> gModules = {
     // put modules here

--- a/rover-apps/arm/include/AppConfig.h
+++ b/rover-apps/arm/include/AppConfig.h
@@ -5,7 +5,9 @@
 #include "Module.h"
 #include "WatchdogModule.h"
 
-WatchdogModule arm_watchdog;
+std::chrono::milliseconds countdown_ms = 1000ms; /*Test value*/
+
+WatchdogModule arm_watchdog(countdown_ms);
 
 std::vector<Module*> gModules = {
     // put modules here

--- a/rover-apps/arm/include/AppConfig.h
+++ b/rover-apps/arm/include/AppConfig.h
@@ -7,7 +7,7 @@
 
 std::chrono::milliseconds countdown_ms = 1000ms; /*Test value*/
 
-Module::WatchdogModule arm_watchdog(countdown_ms);
+WatchdogModule arm_watchdog(countdown_ms);
 
 std::vector<Module*> gModules = {
     // put modules here

--- a/rover-apps/arm/include/AppConfig.h
+++ b/rover-apps/arm/include/AppConfig.h
@@ -3,7 +3,12 @@
 #include <vector>
 
 #include "Module.h"
+#include "WatchdogModule.h"
+
+WatchdogModule arm_watchdog;
 
 std::vector<Module*> gModules = {
     // put modules here
-};
+    &arm_watchdog,
+}
+;

--- a/rover-apps/common/CMakeLists.txt
+++ b/rover-apps/common/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(WatchdogModule STATIC)
+target_sources(WatchdogModule PRIVATE src/WatchdogModule.cpp)
+target_include_directories(WatchdogModule PUBLIC include)
+target_link_libraries(WatchdogModule
+        PRIVATE
+        Module
+        mbed-os
+        )

--- a/rover-apps/common/CMakeLists.txt
+++ b/rover-apps/common/CMakeLists.txt
@@ -3,6 +3,6 @@ target_sources(WatchdogModule PRIVATE src/WatchdogModule.cpp)
 target_include_directories(WatchdogModule PUBLIC include)
 target_link_libraries(WatchdogModule
         PRIVATE
-        Module
+        WatchdogWrapper
         mbed-os
         )

--- a/rover-apps/common/include/Module.h
+++ b/rover-apps/common/include/Module.h
@@ -1,5 +1,6 @@
 #pragma once
 
+namespace Module {
 class Module {
  public:
   virtual void periodic_10s(void)   = 0;
@@ -8,3 +9,4 @@ class Module {
   virtual void periodic_10ms(void)  = 0;
   virtual void periodic_1ms(void)   = 0;
 };
+}  // namespace Module

--- a/rover-apps/common/include/Module.h
+++ b/rover-apps/common/include/Module.h
@@ -1,6 +1,5 @@
 #pragma once
 
-namespace Module {
 class Module {
  public:
   virtual void periodic_10s(void)   = 0;
@@ -9,4 +8,3 @@ class Module {
   virtual void periodic_10ms(void)  = 0;
   virtual void periodic_1ms(void)   = 0;
 };
-}  // namespace Module

--- a/rover-apps/common/include/WatchdogModule.h
+++ b/rover-apps/common/include/WatchdogModule.h
@@ -8,20 +8,17 @@ class WatchdogModule final : public Module {
   /* Initiates the watchdog with a countdown
    * @param countdown - max timeout of the watchdog
    * */
-  WatchdogModule(std::chrono::milliseconds countdown = 5000ms);
-
-  /* Logs the last reset due to the watchdog
-   * */
-  void Watchdog_logLastResetReason(void);
+  WatchdogModule();
 
   /* Periodic function to kick the watchdog and restart its timer every 1s
    * */
-  void periodic_10s(void) override {}
   void periodic_1s(void) override;
+
+  void periodic_10s(void) override {}
   void periodic_100ms(void) override {}
   void periodic_10ms(void) override {}
   void periodic_1ms(void) override {}
 
  private:
-  std::chrono::milliseconds countdown_ms; /*max timeout of the watchdog*/
+  static const std::chrono::milliseconds WATCHDOG_DEFAULT_COUNTDOWN;
 };

--- a/rover-apps/common/include/WatchdogModule.h
+++ b/rover-apps/common/include/WatchdogModule.h
@@ -3,7 +3,6 @@
 #include "Module.h"
 #include "mbed.h"
 
-namespace Module {
 class WatchdogModule final : public Module {
  public:
   /* Initiates the watchdog with a countdown
@@ -26,4 +25,3 @@ class WatchdogModule final : public Module {
  private:
   std::chrono::milliseconds countdown_ms; /*max timeout of the watchdog*/
 };
-}  // namespace Module

--- a/rover-apps/common/include/WatchdogModule.h
+++ b/rover-apps/common/include/WatchdogModule.h
@@ -17,7 +17,11 @@ class WatchdogModule final : public Module {
 
   /* Periodic function to kick the watchdog and restart its timer every 1s
    * */
+  void periodic_10s(void) override;
   void periodic_1s(void) override;
+  void periodic_100ms(void) override;
+  void periodic_10ms(void) override;
+  void periodic_1ms(void) override;
 
  private:
   std::chrono::milliseconds countdown_ms; /*max timeout of the watchdog*/

--- a/rover-apps/common/include/WatchdogModule.h
+++ b/rover-apps/common/include/WatchdogModule.h
@@ -3,6 +3,7 @@
 #include "Module.h"
 #include "mbed.h"
 
+namespace Module {
 class WatchdogModule final : public Module {
  public:
   /* Initiates the watchdog with a countdown
@@ -25,3 +26,4 @@ class WatchdogModule final : public Module {
  private:
   std::chrono::milliseconds countdown_ms; /*max timeout of the watchdog*/
 };
+}  // namespace Module

--- a/rover-apps/common/include/WatchdogModule.h
+++ b/rover-apps/common/include/WatchdogModule.h
@@ -16,11 +16,11 @@ class WatchdogModule final : public Module {
 
   /* Periodic function to kick the watchdog and restart its timer every 1s
    * */
-  void periodic_10s(void) override;
+  void periodic_10s(void) override {}
   void periodic_1s(void) override;
-  void periodic_100ms(void) override;
-  void periodic_10ms(void) override;
-  void periodic_1ms(void) override;
+  void periodic_100ms(void) override {}
+  void periodic_10ms(void) override {}
+  void periodic_1ms(void) override {}
 
  private:
   std::chrono::milliseconds countdown_ms; /*max timeout of the watchdog*/

--- a/rover-apps/common/include/WatchdogModule.h
+++ b/rover-apps/common/include/WatchdogModule.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Module.h"
+#include "mbed.h"
+
+namespace Module {
+class WatchdogModule final : public Module {
+ public:
+  /* Initiates the watchdog with a countdown
+   * @param countdown - max timeout of the watchdog
+   * */
+  WatchdogModule(std::chrono::milliseconds countdown = 5000ms);
+
+  /* Logs the last reset due to the watchdog
+   * */
+  void Watchdog_logLastResetReason(void);
+
+  /* Periodic function to kick the watchdog and restart its timer every 1s
+   * */
+  void periodic_1s(void) override;
+
+ private:
+  std::chrono::milliseconds countdown_ms; /*max timeout of the watchdog*/
+};
+}  // namespace Module

--- a/rover-apps/common/src/WatchdogModule.cpp
+++ b/rover-apps/common/src/WatchdogModule.cpp
@@ -4,6 +4,8 @@
 #include "WatchdogWrapper.h"
 #include "mbed.h"
 
+using namespace Module;
+
 WatchdogModule::WatchdogModule(std::chrono::milliseconds countdown) : countdown_ms(countdown) {
   Utility::WatchdogWrapper::startWatchdog(countdown_ms);
 }

--- a/rover-apps/common/src/WatchdogModule.cpp
+++ b/rover-apps/common/src/WatchdogModule.cpp
@@ -4,8 +4,6 @@
 #include "WatchdogWrapper.h"
 #include "mbed.h"
 
-using namespace Module;
-
 WatchdogModule::WatchdogModule(std::chrono::milliseconds countdown) : countdown_ms(countdown) {
   Utility::WatchdogWrapper::startWatchdog(countdown_ms);
 }

--- a/rover-apps/common/src/WatchdogModule.cpp
+++ b/rover-apps/common/src/WatchdogModule.cpp
@@ -4,8 +4,6 @@
 #include "WatchdogWrapper.h"
 #include "mbed.h"
 
-namespace Module;
-
 WatchdogModule::WatchdogModule(std::chrono::milliseconds countdown) : countdown_ms(countdown) {
   Utility::WatchdogWrapper::startWatchdog(countdown_ms);
 }

--- a/rover-apps/common/src/WatchdogModule.cpp
+++ b/rover-apps/common/src/WatchdogModule.cpp
@@ -1,0 +1,20 @@
+#include "WatchdogModule.h"
+
+#include "Module.h"
+#include "WatchdogWrapper.h"
+#include "mbed.h"
+
+namespace Module;
+
+WatchdogModule::WatchdogModule(std::chrono::milliseconds countdown, std::chrono::milliseconds pet)
+    : countdown_ms(countdown) {
+  Utility::WatchdogWrapper::startWatchdog(countdown_ms);
+}
+
+void WatchdogModule::Watchdog_logLastResetReason(void) {
+  Utility::WatchdogWrapper::logResetReason();
+}
+
+void WatchdogModule::periodic_1s(void) {
+  Utility::WatchdogWrapper::petWatchdog();
+}

--- a/rover-apps/common/src/WatchdogModule.cpp
+++ b/rover-apps/common/src/WatchdogModule.cpp
@@ -6,8 +6,7 @@
 
 namespace Module;
 
-WatchdogModule::WatchdogModule(std::chrono::milliseconds countdown, std::chrono::milliseconds pet)
-    : countdown_ms(countdown) {
+WatchdogModule::WatchdogModule(std::chrono::milliseconds countdown) : countdown_ms(countdown) {
   Utility::WatchdogWrapper::startWatchdog(countdown_ms);
 }
 

--- a/rover-apps/common/src/WatchdogModule.cpp
+++ b/rover-apps/common/src/WatchdogModule.cpp
@@ -4,12 +4,11 @@
 #include "WatchdogWrapper.h"
 #include "mbed.h"
 
-WatchdogModule::WatchdogModule(std::chrono::milliseconds countdown) : countdown_ms(countdown) {
-  Utility::WatchdogWrapper::startWatchdog(countdown_ms);
-}
+const std::chrono::milliseconds WatchdogModule::WATCHDOG_DEFAULT_COUNTDOWN = 5000ms;
 
-void WatchdogModule::Watchdog_logLastResetReason(void) {
+WatchdogModule::WatchdogModule(){
   Utility::WatchdogWrapper::logResetReason();
+  Utility::WatchdogWrapper::startWatchdog(WATCHDOG_DEFAULT_COUNTDOWN);
 }
 
 void WatchdogModule::periodic_1s(void) {

--- a/rover-apps/gimbal/CMakeLists.txt
+++ b/rover-apps/gimbal/CMakeLists.txt
@@ -19,6 +19,8 @@ target_link_libraries(gimbal
         CANMsg
         #Sensor
         CurrentSensor
+        #common-modules
+        WatchdogModule
         #Other
         Logger
         uwrt-mars-rover-hw-bridge

--- a/rover-apps/gimbal/include/AppConfig.h
+++ b/rover-apps/gimbal/include/AppConfig.h
@@ -5,9 +5,7 @@
 #include "Module.h"
 #include "WatchdogModule.h"
 
-std::chrono::milliseconds countdown_ms = 1000ms; /*Test value*/
-
-WatchdogModule gimbal_watchdog(countdown_ms);
+WatchdogModule gimbal_watchdog;
 
 std::vector<Module*> gModules = {
     // put modules here

--- a/rover-apps/gimbal/include/AppConfig.h
+++ b/rover-apps/gimbal/include/AppConfig.h
@@ -5,7 +5,9 @@
 #include "Module.h"
 #include "WatchdogModule.h"
 
-WatchdogModule gimbal_watchdog;
+std::chrono::milliseconds countdown_ms = 1000ms; /*Test value*/
+
+WatchdogModule gimbal_watchdog(countdown_ms);
 
 std::vector<Module*> gModules = {
     // put modules here

--- a/rover-apps/gimbal/include/AppConfig.h
+++ b/rover-apps/gimbal/include/AppConfig.h
@@ -7,7 +7,7 @@
 
 std::chrono::milliseconds countdown_ms = 1000ms; /*Test value*/
 
-WatchdogModule gimbal_watchdog(countdown_ms);
+Module::WatchdogModule gimbal_watchdog(countdown_ms);
 
 std::vector<Module*> gModules = {
     // put modules here

--- a/rover-apps/gimbal/include/AppConfig.h
+++ b/rover-apps/gimbal/include/AppConfig.h
@@ -3,7 +3,12 @@
 #include <vector>
 
 #include "Module.h"
+#include "WatchdogModule.h"
+
+WatchdogModule gimbal_watchdog;
 
 std::vector<Module*> gModules = {
     // put modules here
-};
+    &gimbal_watchdog,
+}
+;

--- a/rover-apps/gimbal/include/AppConfig.h
+++ b/rover-apps/gimbal/include/AppConfig.h
@@ -7,7 +7,7 @@
 
 std::chrono::milliseconds countdown_ms = 1000ms; /*Test value*/
 
-Module::WatchdogModule gimbal_watchdog(countdown_ms);
+WatchdogModule gimbal_watchdog(countdown_ms);
 
 std::vector<Module*> gModules = {
     // put modules here

--- a/rover-apps/gimbal/include/AppConfig.h
+++ b/rover-apps/gimbal/include/AppConfig.h
@@ -10,5 +10,4 @@ WatchdogModule gimbal_watchdog;
 std::vector<Module*> gModules = {
     // put modules here
     &gimbal_watchdog,
-}
-;
+};

--- a/rover-apps/science/CMakeLists.txt
+++ b/rover-apps/science/CMakeLists.txt
@@ -22,6 +22,8 @@ target_link_libraries(science
         #Sensor
         CurrentSensor
         AdafruitSTEMMA
+        #common-modules
+        WatchdogModule
         #Other
         uwrt-mars-rover-hw-bridge
         Logger

--- a/rover-apps/science/include/AppConfig.h
+++ b/rover-apps/science/include/AppConfig.h
@@ -7,7 +7,7 @@
 
 std::chrono::milliseconds countdown_ms = 1000ms; /*Test value*/
 
-Module::WatchdogModule science_watchdog(countdown_ms);
+WatchdogModule science_watchdog(countdown_ms);
 
 std::vector<Module*> gModules = {
     // put modules here

--- a/rover-apps/science/include/AppConfig.h
+++ b/rover-apps/science/include/AppConfig.h
@@ -7,7 +7,7 @@
 
 std::chrono::milliseconds countdown_ms = 1000ms; /*Test value*/
 
-WatchdogModule science_watchdog(countdown_ms);
+Module::WatchdogModule science_watchdog(countdown_ms);
 
 std::vector<Module*> gModules = {
     // put modules here

--- a/rover-apps/science/include/AppConfig.h
+++ b/rover-apps/science/include/AppConfig.h
@@ -5,7 +5,9 @@
 #include "Module.h"
 #include "WatchdogModule.h"
 
-WatchdogModule science_watchdog;
+std::chrono::milliseconds countdown_ms = 1000ms; /*Test value*/
+
+WatchdogModule science_watchdog(countdown_ms);
 
 std::vector<Module*> gModules = {
     // put modules here

--- a/rover-apps/science/include/AppConfig.h
+++ b/rover-apps/science/include/AppConfig.h
@@ -10,5 +10,4 @@ WatchdogModule science_watchdog;
 std::vector<Module*> gModules = {
     // put modules here
     &science_watchdog,
-}
-;
+};

--- a/rover-apps/science/include/AppConfig.h
+++ b/rover-apps/science/include/AppConfig.h
@@ -5,9 +5,7 @@
 #include "Module.h"
 #include "WatchdogModule.h"
 
-std::chrono::milliseconds countdown_ms = 1000ms; /*Test value*/
-
-WatchdogModule science_watchdog(countdown_ms);
+WatchdogModule science_watchdog;
 
 std::vector<Module*> gModules = {
     // put modules here

--- a/rover-apps/science/include/AppConfig.h
+++ b/rover-apps/science/include/AppConfig.h
@@ -3,7 +3,12 @@
 #include <vector>
 
 #include "Module.h"
+#include "WatchdogModule.h"
+
+WatchdogModule science_watchdog;
 
 std::vector<Module*> gModules = {
     // put modules here
-};
+    &science_watchdog,
+}
+;

--- a/test-apps/test-watchdog/src/main.cpp
+++ b/test-apps/test-watchdog/src/main.cpp
@@ -2,7 +2,8 @@
 #include "mbed.h"
 
 Thread pet_thread;
-std::chrono::milliseconds pet_ms = 200ms;
+std::chrono::milliseconds countdown_ms = 1000ms;
+std::chrono::milliseconds pet_ms       = 200ms;
 
 void pet_dog_task(std::chrono::milliseconds *pet_ms) {
   while (1) {
@@ -13,7 +14,7 @@ void pet_dog_task(std::chrono::milliseconds *pet_ms) {
 
 int main() {
   Utility::WatchdogWrapper::logResetReason();
-  Utility::WatchdogWrapper::startWatchdog();
+  Utility::WatchdogWrapper::startWatchdog(countdown_ms);
   pet_thread.start(callback(pet_dog_task, &pet_ms));
   ThisThread::sleep_for(2000ms);
   MBED_ASSERT(false);

--- a/test-apps/test-watchdog/src/main.cpp
+++ b/test-apps/test-watchdog/src/main.cpp
@@ -1,12 +1,21 @@
 #include "WatchdogWrapper.h"
 #include "mbed.h"
 
+Thread pet_thread;
 std::chrono::milliseconds countdown_ms = 1000ms;
 std::chrono::milliseconds pet_ms       = 200ms;
 
+void periodic(std::chrono::milliseconds *pet_ms) {
+  while (1) {
+    Utility::WatchdogWrapper::petWatchdog();
+    ThisThread::sleep_for(*pet_ms);
+  }
+}
+
 int main() {
   Utility::WatchdogWrapper::logResetReason();
-  Utility::WatchdogWrapper::startWatchdog(countdown_ms, pet_ms);
+  Utility::WatchdogWrapper::startWatchdog(countdown_ms);
+  pet_thread.start(callback(periodic, &pet_ms));
   ThisThread::sleep_for(2000ms);
   MBED_ASSERT(false);
 }

--- a/test-apps/test-watchdog/src/main.cpp
+++ b/test-apps/test-watchdog/src/main.cpp
@@ -2,8 +2,7 @@
 #include "mbed.h"
 
 Thread pet_thread;
-std::chrono::milliseconds countdown_ms = 1000ms;
-std::chrono::milliseconds pet_ms       = 200ms;
+std::chrono::milliseconds pet_ms = 200ms;
 
 void pet_dog_task(std::chrono::milliseconds *pet_ms) {
   while (1) {
@@ -14,8 +13,8 @@ void pet_dog_task(std::chrono::milliseconds *pet_ms) {
 
 int main() {
   Utility::WatchdogWrapper::logResetReason();
-  Utility::WatchdogWrapper::startWatchdog(countdown_ms);
-  pet_thread.start(callback(periodic, &pet_ms));
+  Utility::WatchdogWrapper::startWatchdog();
+  pet_thread.start(callback(pet_dog_task, &pet_ms));
   ThisThread::sleep_for(2000ms);
   MBED_ASSERT(false);
 }


### PR DESCRIPTION
Create a module to make use the watchdog library (common to all apps). This should either refactor and make use of our current `WatchdogWrapper` library, or migrate the `WatchdogWrapper` implementation to the module. Make sure to develop off of the `app-structure-redesign` branch.

See confluence for project outline: https://wiki.uwaterloo.ca/display/UWRT/FW+Rover+Apps+Structure